### PR TITLE
Rename SKIN_TONE label to Skin Tone

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -175,7 +175,7 @@
 			<key>description</key>
 			<string>Default skin tone for emojis</string>
 			<key>label</key>
-			<string>SKIN_TONE</string>
+			<string>Skin Tone</string>
 			<key>type</key>
 			<string>popupbutton</string>
 			<key>variable</key>


### PR DESCRIPTION
Right now the label (which is user facing) is named the same as the variable. This names it more like an option, which is consistent with the label for the keyword.